### PR TITLE
replace px-to-mm conversion value

### DIFF
--- a/gl2qgis/gl2qgis.py
+++ b/gl2qgis/gl2qgis.py
@@ -17,7 +17,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor
 from qgis.core import *
 
-PX_TO_MM = 0.26  # TODO: some good conversion ratio
+PX_TO_MM = 0.13229166
 
 
 def parse_color(json_color):


### PR DESCRIPTION
In gl2qgis.py, pixel and mm conversion value is defined as following.

```
PX_TO_MM = 0.26  # TODO: some good conversion ratio
```

Apparently, this value may be calculated by default DPI-96 and Inch/mm-25.4.
Lines drawn with this value looks thicker than Raster.

### Vector, 0.26
![0 26-2](https://user-images.githubusercontent.com/20744195/83384007-4cf19c00-a421-11ea-81bc-60b4cb9c7161.png)

### Raster
![0 26-1](https://user-images.githubusercontent.com/20744195/83383975-3a776280-a421-11ea-81ab-6130e792636e.png)

When I set a value just half of it, a difference of vector and raster become smaller.

```
PX_TO_MM = 0.13229166
```

### Vector, 0.13229166
![0 13-2](https://user-images.githubusercontent.com/20744195/83384147-9b069f80-a421-11ea-8078-3bc277bbbf77.png)

### Raster
![0 13-1](https://user-images.githubusercontent.com/20744195/83384133-9346fb00-a421-11ea-8163-a5bea485a00e.png)

I think this may be caused by DPI processing in QGIS although I'm not familiar with.
In any case, I feel line-width looks better so that opened this pull request.