### PR TITLE
Fix to get attributes only from valid layers

### DIFF
--- a/maptiler.py
+++ b/maptiler.py
@@ -175,6 +175,9 @@ class MapTiler:
         copyrights = []
         root_group = self.iface.layerTreeView().layerTreeModel().rootGroup()
         for l in root_group.findLayers():
+            # when invalid layer is in Browser
+            if not isinstance(l.layer(), QgsMapLayer):
+                continue
             if l.isVisible():
                 attribution = l.layer().attribution()
                 attribution = re.sub(


### PR DESCRIPTION
close #56 

The cause of this issue is trying to get even from invalid layer, by attribute() that is defined in QgsMapLayer class.
So, fix to skip getting a attribution when a target layer is invalid, in other words is None type. (valid is QgsMapLayer type)