### PR TITLE
Added action in cotextual to open customize page

### DIFF
--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -2,6 +2,7 @@ import os
 import sip
 import json
 import requests
+import webbrowser
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMessageBox
 from qgis.core import *
@@ -82,6 +83,15 @@ class MapDataItem(QgsDataItem):
             remove_action = QAction(QIcon(), 'Remove', parent)
             remove_action.triggered.connect(self._remove)
             actions.append(remove_action)
+
+            if 'customize_url' in self._dataset:
+                separator = QAction(QIcon(), '', parent)
+                separator.setSeparator(True)
+                actions.append(separator)
+
+                open_customize_url_action = QAction(QIcon(), 'Customize in Cloud', parent)
+                open_customize_url_action.triggered.connect(self._open_customize_url)
+                actions.append(open_customize_url_action)
 
         return actions
 
@@ -324,6 +334,10 @@ class MapDataItem(QgsDataItem):
         selectedmaps.remove(self._name)
         smanager.store_setting('selectedmaps', selectedmaps)
         self.refreshConnections()
+
+    def _open_customize_url(self):
+        customize_url = self._dataset.get("customize_url")
+        webbrowser.open(customize_url)
 
     def _openConfigueDialog(self):
         configue_dialog = ConfigueDialog()

--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -89,7 +89,7 @@ class MapDataItem(QgsDataItem):
                 separator.setSeparator(True)
                 actions.append(separator)
 
-                open_customize_url_action = QAction(QIcon(), 'Customize in Cloud', parent)
+                open_customize_url_action = QAction(QIcon(), 'Customize in Cloud ↗', parent)
                 open_customize_url_action.triggered.connect(self._open_customize_url)
                 actions.append(open_customize_url_action)
 

--- a/mapdatasets.py
+++ b/mapdatasets.py
@@ -1,11 +1,13 @@
 STANDARD_DATASET = {
     'Basic': {
         'raster': r'https://api.maptiler.com/maps/basic/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/basic/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/basic/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#basic'
     },
     'Bright': {
         'raster': r'https://api.maptiler.com/maps/bright/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/bright/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/bright/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#bright'
     },
     'Dark Matter': {
         'raster': r'https://api.maptiler.com/maps/darkmatter/256/tiles.json?key=',
@@ -13,35 +15,42 @@ STANDARD_DATASET = {
     },
     'Pastel': {
         'raster': r'https://api.maptiler.com/maps/pastel/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/pastel/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/pastel/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#pastel'
     },
     'Positron': {
         'raster': r'https://api.maptiler.com/maps/positron/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/positron/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/positron/style.json?key=',
     },
     'Satellite': {
         'raster': r'https://api.maptiler.com/maps/hybrid/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/hybrid/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/hybrid/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#hybrid'
     },
     'Streets': {
         'raster': r'https://api.maptiler.com/maps/streets/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/streets/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/streets/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#streets'
     },
     'Toner': {
         'raster': r'https://api.maptiler.com/maps/toner/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/toner/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/toner/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#toner'
     },
     'Topo': {
         'raster': r'https://api.maptiler.com/maps/topo/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/topo/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/topo/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#topo'
     },
     'Topographique': {
         'raster': r'https://api.maptiler.com/maps/topographique/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/topographique/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/topographique/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#topographique'
     },
     'Voyager': {
         'raster': r'https://api.maptiler.com/maps/voyager/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/voyager/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/voyager/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#voyager'
     }
 }
 
@@ -78,18 +87,22 @@ LOCAL_NL_DATASET = {
 LOCAL_UK_DATASET = {
     'UK OS Open Zoomstack Light': {
         'raster': r'https://api.maptiler.com/maps/uk-openzoomstack-light/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-light/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-light/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#uk-openzoomstack-light'
     },
     'UK OS Open Zoomstack Night': {
         'raster': r'https://api.maptiler.com/maps/uk-openzoomstack-night/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-night/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-night/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#uk-openzoomstack-night'
     },
     'UK OS Open Zoomstack Outdoor': {
         'raster': r'https://api.maptiler.com/maps/uk-openzoomstack-outdoor/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-outdoor/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-outdoor/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#uk-openzoomstack-outdoor'
     },
     'UK OS Open Zoomstack Road': {
         'raster': r'https://api.maptiler.com/maps/uk-openzoomstack-road/256/tiles.json?key=',
-        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-road/style.json?key='
+        'vector': r'https://api.maptiler.com/maps/uk-openzoomstack-road/style.json?key=',
+        'customize_url': r'https://cloud.maptiler.com/customize/#uk-openzoomstack-road'
     }
 }


### PR DESCRIPTION
close #66 

Implemented actions to open customize page in contextual menu.
Because some style don't have customize page as you know, add the action to only items having 'customize_url', hard-coded in mapdatasets.py.