### PR TITLE
Support Sprite/fill-pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .DS_Store
+gl2qgis/sprites/

--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -18,6 +18,7 @@ from . import utils
 IMGS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "imgs")
 DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 BG_VECTOR_PATH = os.path.join(DATA_PATH, "background.geojson")
+SPRITES_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gl2qgis", "sprites")
 
 
 class MapDataItem(QgsDataItem):
@@ -205,8 +206,10 @@ class MapDataItem(QgsDataItem):
                                      attribution_text: str,):
         proj = QgsProject().instance()
 
-        SPRITES_PATH = os.path.join(DATA_PATH, "sprites")
-        shutil.rmtree(SPRITES_PATH)
+        try:
+            shutil.rmtree(SPRITES_PATH)
+        except:
+            print("skip remove sprites dir")
         os.mkdir(SPRITES_PATH)
         converter.write_sprite_imgs_from_style_json(style_json_data, SPRITES_PATH)
 

--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -206,11 +206,7 @@ class MapDataItem(QgsDataItem):
                                      attribution_text: str,):
         proj = QgsProject().instance()
 
-        try:
-            shutil.rmtree(SPRITES_PATH)
-        except:
-            print("skip remove sprites dir")
-        os.mkdir(SPRITES_PATH)
+        os.makedirs(SPRITES_PATH, exist_ok=True)
         converter.write_sprite_imgs_from_style_json(style_json_data, SPRITES_PATH)
 
         # Add other layers from sources

--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -3,6 +3,7 @@ import sip
 import json
 import requests
 import webbrowser
+import shutil
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMessageBox
 from qgis.core import *
@@ -197,11 +198,17 @@ class MapDataItem(QgsDataItem):
             self._add_vtlayer_from_tile_json(
                 tile_json_data, node_map, attribution_text)
 
+
     def _add_vtlayer_from_style_json(self,
                                      style_json_data: dict,
                                      target_node: QgsLayerTreeGroup,
                                      attribution_text: str,):
         proj = QgsProject().instance()
+
+        SPRITES_PATH = os.path.join(DATA_PATH, "sprites")
+        shutil.rmtree(SPRITES_PATH)
+        os.mkdir(SPRITES_PATH)
+        converter.write_sprite_imgs_from_style_json(style_json_data, SPRITES_PATH)
 
         # Add other layers from sources
         sources = converter.get_sources_dict_from_style_json(

--- a/gl2qgis/gl2qgis.py
+++ b/gl2qgis/gl2qgis.py
@@ -447,21 +447,23 @@ def parse_fill_layer(json_layer):
     sym = QgsSymbol.defaultSymbol(QgsWkbTypes.PolygonGeometry)
     fill_symbol = sym.symbolLayer(0)
 
-    for dd_key, dd_expression in dd_properties.items():
-        fill_symbol.setDataDefinedProperty(dd_key, QgsProperty.fromExpression(dd_expression))
-    if fill_opacity:
-        sym.setOpacity(fill_opacity)
-    if fill_color:
-        fill_symbol.setColor(fill_color)
-    if fill_outline_color:
-        fill_symbol.setStrokeColor(fill_outline_color)
-
     #when fill-pattern exists, set and override sprite
     fill_pattern = json_paint.get("fill-pattern")
     if fill_pattern:
         SPRITES_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sprites")
-        fill_symbol = QgsRasterFillSymbolLayer(os.path.join(SPRITES_PATH, fill_pattern + ".png"))
-        sym.changeSymbolLayer(0, fill_symbol)
+        raster_fill_symbol = QgsRasterFillSymbolLayer(os.path.join(SPRITES_PATH, fill_pattern + ".png"))
+        sym.appendSymbolLayer(raster_fill_symbol)
+
+    for dd_key, dd_expression in dd_properties.items():
+        fill_symbol.setDataDefinedProperty(dd_key, QgsProperty.fromExpression(dd_expression))
+    if fill_opacity:
+        sym.setOpacity(fill_opacity)
+    if fill_outline_color:
+        fill_symbol.setStrokeColor(fill_outline_color)
+    if fill_color:
+        fill_symbol.setColor(fill_color)
+    else:
+        fill_symbol.setColor(parse_color("rgba(0, 0, 0, 0.0)"))
 
     st = QgsVectorTileBasicRendererStyle()
     st.setGeometryType(QgsWkbTypes.PolygonGeometry)

--- a/gl2qgis/gl2qgis.py
+++ b/gl2qgis/gl2qgis.py
@@ -447,7 +447,7 @@ def parse_fill_layer(json_layer):
     sym = QgsSymbol.defaultSymbol(QgsWkbTypes.PolygonGeometry)
     fill_symbol = sym.symbolLayer(0)
 
-    #when fill-pattern exists, set and override sprite
+    #when fill-pattern exists, set and insert RasterFillSymbolLayer
     fill_pattern = json_paint.get("fill-pattern")
     if fill_pattern:
         SPRITES_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sprites")
@@ -462,13 +462,13 @@ def parse_fill_layer(json_layer):
     if fill_outline_color:
         fill_symbol.setStrokeColor(fill_outline_color)
     else:
-        #fully transparent color
-        fill_symbol.setStrokeColor(parse_color("rgba(0, 0, 0, 0.0)"))
+        transparent_color = parse_color("rgba(0, 0, 0, 0.0)")
+        fill_symbol.setStrokeColor(transparent_color)
     if fill_color:
         fill_symbol.setColor(fill_color)
     else:
-        #fully transparent color
-        fill_symbol.setColor(parse_color("rgba(0, 0, 0, 0.0)"))
+        transparent_color = parse_color("rgba(0, 0, 0, 0.0)")
+        fill_symbol.setColor(transparent_color)
 
     st = QgsVectorTileBasicRendererStyle()
     st.setGeometryType(QgsWkbTypes.PolygonGeometry)

--- a/gl2qgis/gl2qgis.py
+++ b/gl2qgis/gl2qgis.py
@@ -456,13 +456,18 @@ def parse_fill_layer(json_layer):
 
     for dd_key, dd_expression in dd_properties.items():
         fill_symbol.setDataDefinedProperty(dd_key, QgsProperty.fromExpression(dd_expression))
+    
     if fill_opacity:
         sym.setOpacity(fill_opacity)
     if fill_outline_color:
         fill_symbol.setStrokeColor(fill_outline_color)
+    else:
+        #fully transparent color
+        fill_symbol.setStrokeColor(parse_color("rgba(0, 0, 0, 0.0)"))
     if fill_color:
         fill_symbol.setColor(fill_color)
     else:
+        #fully transparent color
         fill_symbol.setColor(parse_color("rgba(0, 0, 0, 0.0)"))
 
     st = QgsVectorTileBasicRendererStyle()


### PR DESCRIPTION
Related #69 

https://docs.mapbox.com/mapbox-gl-js/style-spec/sprite/
In the specification, Sprites can be used in background-pattern, fill-pattern, line-pattern, fill-extrusion-pattern and icon-image.

I tried each points one by one, first, I've implemented fill-pattern-sprite.
I'll try line-pattern next.