### PR TITLE
Fix / opacity-stops parsing

### DIFF
--- a/gl2qgis/converter.py
+++ b/gl2qgis/converter.py
@@ -145,8 +145,17 @@ def get_raster_renderer_resampler(renderer, layer_json: dict):
         if key == "opacity":
             parsed_opacity = 1.0
             if not isinstance(value, (str, float, int)):
-                parsed_opacity = 1.0
-                print(f"Could not parse raster opacity {value}, setting 1.0.")
+                
+                if isinstance(value, (dict)):
+                    #e.g. {'stops': [[1, 0.2], [13, 0.1], [16, 0]]}
+                    stops = value.get("stops")
+                    minzoom_opacity = stops[0][1]
+                    maxzoom_opacity = stops[-1][1]
+                    parsed_opacity = (minzoom_opacity + maxzoom_opacity) / 2
+                else:
+                    #list
+                    parsed_opacity = 1.0
+                    print(f"Could not parse raster opacity {value}, setting 1.0.")
             else:
                 parsed_opacity = float(value)
             styled_renderer.setOpacity(parsed_opacity)


### PR DESCRIPTION
Fix a problem a opacity cannot be correctly apply when raster layer has opacity as dict of stops.

e.g. JP MIERUNE Streets, hillshade
opacity: {'stops': [[1, 0.2], [13, 0.1], [16, 0]]}

In this case, the opacity is set as 1.0 with following message.
```
Could not parse raster opacity {'stops': [[1, 0.2], [13, 0.1], [16, 0]]}, setting 1.0.
```

I've fixed to set a opacity as average of first-stop and final-stop values.
first-stop:[1, 0.2]
final-stop:[16, 0]
average value = (0.2 + 0) /2 = 0.1