### PR TITLE
Fix to avoid calling an unset variable

### DIFF
--- a/gl2qgis/converter.py
+++ b/gl2qgis/converter.py
@@ -67,6 +67,7 @@ def get_sources_dict_from_style_json(style_json_data: dict) -> dict:
             if source_data.get("tiles") is None:
                 continue
             layer_zxy_url = source_data.get("tiles")[0]
+            source_name = source_id
 
         source_type = source_data.get("type")
         source_zxy_dict[source_id] = {


### PR DESCRIPTION
When the style.json content  contains something like below
```
"sources": {
        "natural_earth": {
            "tiles": [
                "http://naturalearthtiles.lukasmartinelli.ch/tiles/natural_earth.vector/{z}/{x}/{y}.pbf"
            ],
            "maxzoom": 7,
            "type": "vector"
        },
        "ne_2_hr_lc_sr": {
            "tiles": [
                "http://naturalearthtiles.lukasmartinelli.ch/tiles/natural_earth_2_shaded_relief.raster/{z}/{x}/{y}.png"
            ],
            "type": "raster",
            "tileSize": 256,
            "maxzoom": 6
        }
    },
```
The code goes in the `else` block from

```python
        else:
            if source_data.get("tiles") is None:
                continue
            layer_zxy_url = source_data.get("tiles")[0]
            source_name = source_id
 
        source_type = source_data.get("type")
        source_zxy_dict[source_id] = {
            "name": source_name, "zxy_url": layer_zxy_url,
            "type": source_type, "order": source_order.index(source_id),
            "maxzoom": max_zoom, "minzoom": min_zoom
        }
```

Just after we call `source_name`. As it's undefined, it throws an error. You can try using this url https://gist.githubusercontent.com/ThomasG77/c7f4c9ee182324fa289f855a3241cadc/raw/fe90463b0164592007ffd3236e28edf11241c10e/natural-earth-modified-style.json (a copy ending with tile.json of http://naturalearthtiles.lukasmartinelli.ch/maps/natural_earth.vector.json) to reproduce before the fix.