### PR TITLE
Fix/#120 fill pattern dict

### DIFF
--- a/configue_dialog.py
+++ b/configue_dialog.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import warnings
 
 from PyQt5 import uic, QtWidgets, QtCore, QtGui
 from qgis.core import Qgis
@@ -13,8 +14,10 @@ class ConfigueDialog(QtWidgets.QDialog):
     def __init__(self):
         super().__init__()
 
+        warnings.simplefilter('ignore', DeprecationWarning)
         self.ui = uic.loadUi(os.path.join(os.path.dirname(
             __file__), 'configue_dialog_base.ui'), self)
+        warnings.resetwarnings()
 
         self.ui.button_box.accepted.connect(self._accepted)
         self.ui.button_box.rejected.connect(self._rejected)

--- a/configue_dialog.py
+++ b/configue_dialog.py
@@ -14,10 +14,8 @@ class ConfigueDialog(QtWidgets.QDialog):
     def __init__(self):
         super().__init__()
 
-        warnings.simplefilter('ignore', DeprecationWarning)
         self.ui = uic.loadUi(os.path.join(os.path.dirname(
             __file__), 'configue_dialog_base.ui'), self)
-        warnings.resetwarnings()
 
         self.ui.button_box.accepted.connect(self._accepted)
         self.ui.button_box.rejected.connect(self._rejected)

--- a/configue_dialog.py
+++ b/configue_dialog.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import warnings
 
 from PyQt5 import uic, QtWidgets, QtCore, QtGui
 from qgis.core import Qgis

--- a/gl2qgis/gl2qgis.py
+++ b/gl2qgis/gl2qgis.py
@@ -116,7 +116,6 @@ def parse_value(json_value):
 def parse_expression(json_expr):
     """ Parses expression into QGIS expression string """
     op = json_expr[0]
-    print(op)
     if op == 'all':
         lst = [parse_value(v) for v in json_expr[1:]]
         if None in lst:
@@ -124,10 +123,7 @@ def parse_expression(json_expr):
             return
         return "({})".format(") AND (".join(lst))
     elif op == 'any':
-        print("op is:")
-        print(json_expr)
         lst = [parse_value(v) for v in json_expr[1:]]
-        print(lst)
         return "({})".format(") OR (".join(lst))
     elif op == 'none':
         lst = [parse_value(v) for v in json_expr[1:]]

--- a/gl2qgis/gl2qgis.py
+++ b/gl2qgis/gl2qgis.py
@@ -116,6 +116,7 @@ def parse_value(json_value):
 def parse_expression(json_expr):
     """ Parses expression into QGIS expression string """
     op = json_expr[0]
+    print(op)
     if op == 'all':
         lst = [parse_value(v) for v in json_expr[1:]]
         if None in lst:
@@ -128,6 +129,12 @@ def parse_expression(json_expr):
     elif op == 'none':
         lst = [parse_value(v) for v in json_expr[1:]]
         return "NOT ({})".format(") AND NOT (".join(lst))
+    elif op == '!':
+        # ! inverts next expression meaning
+        contra_json_expr = json_expr[1]
+        contra_json_expr[0] = op + contra_json_expr[0]
+        # ['!', ['has', 'level']] -> ['!has', 'level']
+        return parse_key(contra_json_expr)
     elif op in ("==", "!=", ">=", ">", "<=", "<"):
         # use IS and NOT IS instead of = and != because they can deal with NULL values
         if op == "==":

--- a/gl2qgis/gl2qgis.py
+++ b/gl2qgis/gl2qgis.py
@@ -116,7 +116,6 @@ def parse_value(json_value):
 def parse_expression(json_expr):
     """ Parses expression into QGIS expression string """
     op = json_expr[0]
-    print(op)
     if op == 'all':
         lst = [parse_value(v) for v in json_expr[1:]]
         if None in lst:


### PR DESCRIPTION
close #120 

https://vecto-dev.teritorio.xyz/styles/teritorio-tourism-dev/style.json

## Abstract

To read this style.json, I found three problems in parsing.

- fill-pattern parsing
- expression parsing - list
- expression parsing - "!"

## fill-pattern parsing
This plugin now postulate a type of fill-pattern value is String but not always so.
If show different sprites per zoomlevel, we may need to separate layers into some layers I think and it takes large costs.
Therefore now I implemented to parse expression by simplifying them into one sprite (likely highest resolution img), like following.
```
# {"stops":[[11,"wetland8"],[12,"wetland16"],[13,"wetland32"],[14,"wetland64"]]}
# -> "wetland64"
```

## expression parsing - list
Above style.json include sentence like below.
```
"filter":["all",["==",["geometry-type"],"Point"]
```
["geometry-type"] means an array has length 1 but parsing didn't expect this, fixed.

## expression parsing - "!"
Expression can have one of many operand. One of them is "!" but this is not expected.
If an expression has this, I implemented to invert meaning of next expression of this operand, like following.

```
# ['!', ['has', 'level']] -> ['!has', 'level']
```