### PR TITLE
GE-1042 fix copyrights

### DIFF
--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -438,6 +438,14 @@ class MapDataItem(QgsDataItem):
                 if maptiler_attribution:
                     attribution = maptiler_attribution.get("attribution", "")
                     attribution_text = str(attribution)
+                else:
+                    src_attr_set = set()
+                    for source_name, source_data in sources.items():
+                        tiles_json_url = source_data.get("url")
+                        if tiles_json_url is not None:
+                            tiles_json_data = utils.qgis_request_json(tiles_json_url)
+                            src_attr_set.add(tiles_json_data.get("attribution"))
+                    attribution_text = "".join(src_attr_set)
             else:
                 attribution_text = custom_json_data.get("attribution", "")
 

--- a/maptiler.py
+++ b/maptiler.py
@@ -213,6 +213,7 @@ class MapTiler:
             attribution = re.sub(
                 '<a.*?>|</a>', '', attribution).replace('&copy;', '©').replace('©', '!!!©')
             parsed_attributions = attribution.split('!!!')
+            parsed_attributions = list(map(str.strip, parsed_attributions))
             for attr in parsed_attributions:
                 if attr == '':
                     continue

--- a/maptiler.py
+++ b/maptiler.py
@@ -224,8 +224,7 @@ class MapTiler:
             # when invalid layer is in Browser
             if not isinstance(l.layer(), QgsMapLayer):
                 continue
-            if l.isVisible():
-                target_layers.append(l.layer())
+            target_layers.append(l.layer())
 
         for l in target_layers:
             attribution = l.attribution()

--- a/maptiler.py
+++ b/maptiler.py
@@ -73,11 +73,11 @@ class MapTiler:
         self.pluginIsActive = False
 
         #copyright variables
-        self._previous_copyrights_text = ""
         self._previous_copyrights = []
         self._default_copyright = QgsProject.instance().readEntry("CopyrightLabel", "/Label")[0]
         self._default_copyright_is_visible = QgsProject.instance().readEntry("CopyrightLabel", "/Enabled")[0] == "true"
         self.proj.readProjectWithContext.connect(lambda a0, context:self._on_custom_project_loaded(a0, context))
+        self.proj.cleared.connect(self._on_project_closed)
 
     # noinspection PyMethodMayBeStatic
 
@@ -127,6 +127,12 @@ class MapTiler:
             
         self._default_copyright = copyright_label_in_the_project
         self._default_copyright_is_visible = copyright_enabled_in_the_project
+        QgsProject.instance().writeEntry("CopyrightLabel", "/Label", self._default_copyright)
+        QgsProject.instance().writeEntry("CopyrightLabel", "/Enabled", self._default_copyright_is_visible)
+
+    def _on_project_closed(self):
+        self._default_copyright = ""
+        self._default_copyright_is_visible = False
 
     def _activate_copyrights(self):
         # self.iface.layerTreeView().clicked.connect(self._write_copyright_entries)

--- a/maptiler.py
+++ b/maptiler.py
@@ -129,14 +129,14 @@ class MapTiler:
         self._default_copyright_is_visible = copyright_enabled_in_the_project
 
     def _activate_copyrights(self):
-        self.iface.layerTreeView().clicked.connect(self._write_copyright_entries)
-        self.iface.layerTreeView().currentLayerChanged.connect(self._write_copyright_entries)
+        # self.iface.layerTreeView().clicked.connect(self._write_copyright_entries)
+        # self.iface.layerTreeView().currentLayerChanged.connect(self._write_copyright_entries)
         self.proj.layersAdded.connect(self._write_copyright_entries)
         self.proj.layersRemoved.connect(self._write_copyright_entries)
 
     def _deactivate_copyrights(self):
-        self.iface.layerTreeView().clicked.disconnect(self._write_copyright_entries)
-        self.iface.layerTreeView().currentLayerChanged.disconnect(self._write_copyright_entries)
+        # self.iface.layerTreeView().clicked.disconnect(self._write_copyright_entries)
+        # self.iface.layerTreeView().currentLayerChanged.disconnect(self._write_copyright_entries)
         self.proj.layersAdded.disconnect(self._write_copyright_entries)
         self.proj.layersRemoved.disconnect(self._write_copyright_entries)
         QgsProject.instance().writeEntry("CopyrightLabel", "/Label", self._default_copyright)

--- a/maptiler.py
+++ b/maptiler.py
@@ -73,7 +73,6 @@ class MapTiler:
         self.pluginIsActive = False
 
         #copyright variables
-        self._is_copyright_written_by_plugin = False
         self._previous_copyrights_text = ""
         self._previous_copyrights = []
         self._default_copyright = QgsProject.instance().readEntry("CopyrightLabel", "/Label")[0]
@@ -166,7 +165,6 @@ class MapTiler:
         copyrights_to_trim = parsed_copyrights + self._previous_copyrights
         trimed_copyrights_text = self._trim_copyrights_to_default(copyrights_to_trim)
         if not trimed_copyrights_text == "":
-            print(trimed_copyrights_text)
             self._default_copyright = trimed_copyrights_text
             self._default_copyright_is_visible = True
 


### PR DESCRIPTION
Fixes attribution when closing/opening various projects with different copyright labels.
Purges plugin's `_default_copyright` when a project is closed.
Estimates whether a layer is added via the plugin and re-render copyright only when such a layer is added or removed.
If a layer which was added via the plugin is selected/unselected (visible/invisible) copyrights are not re-rendered. It is not ideal, a user has to remove the layer completely to remove the layer's copyright as well. But it should solve the problem with the slow GUI mentioned in #132

Fix #129 
Fix #132 
Fix #149 
