### PR TITLE
#191 handle missing userLocale

### DIFF
--- a/maptiler.py
+++ b/maptiler.py
@@ -53,7 +53,6 @@ class MapTiler:
 
         # initialize locale
         locale = (locale[0:2] if (locale := QSettings().value('locale/userLocale')) else 'en')
-
         locale_path = os.path.join(
             self.plugin_dir,
             'i18n',

--- a/maptiler.py
+++ b/maptiler.py
@@ -52,7 +52,8 @@ class MapTiler:
         self.plugin_dir = os.path.dirname(__file__)
 
         # initialize locale
-        locale = QSettings().value('locale/userLocale')[0:2]
+        locale = (locale[0:2] if (locale := QSettings().value('locale/userLocale')) else 'en')
+
         locale_path = os.path.join(
             self.plugin_dir,
             'i18n',


### PR DESCRIPTION
Fixes #191 
If `locale/userLocale` is missing on user's system, use default `en`.
