### PR TITLE
fix(browser_mapitem.py): Handling missing attribution

### DIFF
--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -516,7 +516,9 @@ class MapDataItem(QgsDataItem):
                         tiles_json_url = source_data.get("url")
                         if tiles_json_url is not None:
                             tiles_json_data = utils.qgis_request_json(tiles_json_url)
-                            src_attr_set.add(tiles_json_data.get("attribution"))
+                            attribution = tiles_json_data.get("attribution")
+                            if attribution is not None:
+                                src_attr_set.add(attribution)
                     attribution_text = "".join(src_attr_set)
             else:
                 attribution_text = custom_json_data.get("attribution", "")


### PR DESCRIPTION
Hello, 
I am using a self-hosted tile server and I noticed that missing attributions were not handled in the code. 
This small PR fixes that. 
Best regards.