### PR TITLE
metadata: add QGIS 4 compatibility

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -5,6 +5,7 @@
 [general]
 name=MapTiler
 qgisMinimumVersion=3.24
+qgisMaximumVersion=4.99
 supportsQt6=yes
 description=Street and satellite base maps with vector tiles
 version=3.5.2


### PR DESCRIPTION
This PR adds QGIS 4 support by updating the metadata. Tested on CachyOS with QGIS 4.0.0 and it works as expected.

Fixes #210
