### PR TITLE
Patch for qgis4 compatibility

### DIFF
--- a/add_connection_dialog.py
+++ b/add_connection_dialog.py
@@ -26,11 +26,10 @@ class AddConnectionDialog(QtWidgets.QDialog):
     def _init_list(self):
         # support multiple selection
         try:
-            self.ui.listWidget.setSelectionMode(
-                QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection) # Qt6 (QGIS4)
+            mode = QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection # Qt6 (QGIS4)
         except AttributeError:
-            self.ui.listWidget.setSelectionMode(
-                QtWidgets.QAbstractItemView.ExtendedSelection) # backward-compatible
+            mode = QtWidgets.QAbstractItemView.ExtendedSelection # backward-compatible
+        self.ui.listWidget.setSelectionMode(mode)
 
         DATASETS = dict(**self.STANDARD_DATASET,
                         **self.LOCAL_JP_DATASET,

--- a/add_connection_dialog.py
+++ b/add_connection_dialog.py
@@ -25,8 +25,12 @@ class AddConnectionDialog(QtWidgets.QDialog):
 
     def _init_list(self):
         # support multiple selection
-        self.ui.listWidget.setSelectionMode(
-            QtWidgets.QAbstractItemView.ExtendedSelection)
+        try:
+            self.ui.listWidget.setSelectionMode(
+                QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection) # Qt6 (QGIS4)
+        except AttributeError:
+            self.ui.listWidget.setSelectionMode(
+                QtWidgets.QAbstractItemView.ExtendedSelection) # backward-compatible
 
         DATASETS = dict(**self.STANDARD_DATASET,
                         **self.LOCAL_JP_DATASET,

--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -463,7 +463,10 @@ class MapDataItem(QgsDataItem):
 
                         html_text += f"<li>{cw}</li>"
                     html_text += "</ul>"
-                    warnings_dlg.setMessage(html_text, 1)
+                    try:
+                        warnings_dlg.setMessage(html_text, Qgis.StringFormat.Html) # Qt6 (QGIS4)
+                    except AttributeError:
+                        warnings_dlg.setMessage(html_text, 1) # backward-compatible
                     warnings_dlg.showMessage()
 
                 button.pressed.connect(show_warnings)

--- a/browser_mapitem.py
+++ b/browser_mapitem.py
@@ -464,9 +464,10 @@ class MapDataItem(QgsDataItem):
                         html_text += f"<li>{cw}</li>"
                     html_text += "</ul>"
                     try:
-                        warnings_dlg.setMessage(html_text, Qgis.StringFormat.Html) # Qt6 (QGIS4)
+                        fmt = Qgis.StringFormat.Html # Qt6 (QGIS4)
                     except AttributeError:
-                        warnings_dlg.setMessage(html_text, 1) # backward-compatible
+                        fmt = 1 # backward-compatible
+                    warnings_dlg.setMessage(html_text, fmt)
                     warnings_dlg.showMessage()
 
                 button.pressed.connect(show_warnings)

--- a/configure_dialog.py
+++ b/configure_dialog.py
@@ -39,14 +39,8 @@ class ConfigureDialog(QtWidgets.QDialog):
             token = cfg.configMap().get("token")
             self.ui.token_txt.setText(token)
 
-        # e.g. QGIS3.10.4 -> 31004
-        qgis_version_str = str(Qgis.QGIS_VERSION_INT)
-        #major_ver = int(qgis_version_str[0])
-        minor_ver = int(qgis_version_str[1:3])
-        #micro_ver = int(qgis_version_str[3:])
-
         # Checkbox are available only when on QGIS version having feature of Vectortile
-        if minor_ver > 12:
+        if Qgis.QGIS_VERSION_INT >= 31300:
             self.ui.vtileCheckBox.setEnabled(True)
             prefervector = bool(int(smanager.get_setting('prefervector')))
             self.ui.vtileCheckBox.setChecked(prefervector)

--- a/metadata.txt
+++ b/metadata.txt
@@ -8,7 +8,7 @@ qgisMinimumVersion=3.24
 qgisMaximumVersion=4.99
 supportsQt6=yes
 description=Street and satellite base maps with vector tiles
-version=3.5.2
+version=3.6
 author=MapTiler
 email=info@maptiler.com
 

--- a/utils.py
+++ b/utils.py
@@ -34,15 +34,11 @@ def validate_credentials() -> bool:
 def is_qgs_vectortile_api_enable():
     # judge vtile is available or not
     # e.g. QGIS3.10.4 -> 31004
-    qgis_version_str = str(Qgis.QGIS_VERSION_INT)
-    minor_ver = int(qgis_version_str[1:3])
-    return minor_ver >= 13
+    return Qgis.QGIS_VERSION_INT >= 31300
 
 
 def is_qgs_early_resampling_enabled():
-    qgis_version_str = str(Qgis.QGIS_VERSION_INT)
-    minor_ver = int(qgis_version_str[1:3])
-    return minor_ver >= 25
+    return Qgis.QGIS_VERSION_INT >= 32500
 
 
 def is_in_darkmode(threshold=383):


### PR DESCRIPTION
In **QGIS4** 

- when using _"Add new map..."_ feature, an error occurs:
```
WARNING    Traceback (most recent call last):
              File "~/Library/Application Support/QGIS/QGIS4/profiles/default/python/plugins/qgis-maptiler-plugin/browser_root_collection.py", line 84, in _open_add_dialog
              add_dialog = AddConnectionDialog()
              ^^^^^^^^^^^^^^^^^^^^^
              File "~/Library/Application Support/QGIS/QGIS4/profiles/default/python/plugins/qgis-maptiler-plugin/add_connection_dialog.py", line 22, in __init__
              self._init_list()
              File "~/Library/Application Support/QGIS/QGIS4/profiles/default/python/plugins/qgis-maptiler-plugin/add_connection_dialog.py", line 29, in _init_list
              QtWidgets.QAbstractItemView.ExtendedSelection)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             AttributeError: type object 'QAbstractItemView' has no attribute 'ExtendedSelection'
```
This happens due to the use of **Qt6** by QGIS4.
The error is caused by `QtWidgets.QAbstractItemView.ExtendedSelection` specifically https://github.com/maptiler/qgis-maptiler-plugin/blob/fba3874a47ba533c9cba90a1cd6d57902a93c838/add_connection_dialog.py#L29


- when adding a vector map layer an error occurs:
```
WARNING    Traceback (most recent call last):
              File "~/Library/Application Support/QGIS/QGIS4/profiles/default/python/plugins/qgis-maptiler-plugin/browser_mapitem.py", line 466, in show_warnings
              warnings_dlg.setMessage(html_text, 1)
             TypeError: setMessage(self, message: str|None, format: Qgis.StringFormat): argument 2 has unexpected type 'int'
```
This happens because **Qt6** in QGIS4 requires string format to be a `Qgis.StringFormat` (as stated in the error message).
The error is caused by `warnings_dlg.setMessage(html_text, 1)` specifically https://github.com/maptiler/qgis-maptiler-plugin/blob/fba3874a47ba533c9cba90a1cd6d57902a93c838/browser_mapitem.py#L466


(tested on QGIS 4.0.2 installed via homebrew cask on macOS 26.4.1 Apple Silicone)


This PR provides backward-compatible fixes.
